### PR TITLE
Option to save the change set's package.xml locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install -g sfdx-changeset
 $ sfdx COMMAND
 running command...
 $ sfdx (-v|--version|version)
-sfdx-changeset/0.1.0 darwin-x64 node-v11.9.0
+sfdx-changeset/0.1.0 darwin-x64 node-v12.19.0
 $ sfdx --help [COMMAND]
 USAGE
   $ sfdx COMMAND
@@ -30,29 +30,51 @@ USAGE
 ```
 <!-- usagestop -->
 <!-- commands -->
-* [`sfdx changeset:retrieve -c <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal]`](#sfdx-changesetretrieve--c-string--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfatal)
+* [`sfdx changeset:retrieve -c <string> [-n <string>] [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal]`](#sfdx-changesetretrieve--c-string--n-string--p--u-string---apiversion-string---json---loglevel-tracedebuginfowarnerrorfatal)
 
-## `sfdx changeset:retrieve -c <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal]`
+## `sfdx changeset:retrieve -c <string> [-n <string>] [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal]`
 
 Download a changeset to the project
 
 ```
 USAGE
-  $ sfdx changeset:retrieve -c <string> [-u <string>] [--apiversion <string>] [--json] [--loglevel 
+  $ sfdx changeset:retrieve -c <string> [-n <string>] [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel 
   trace|debug|info|warn|error|fatal]
 
 OPTIONS
   -c, --changesetname=changesetname               (required) name of changeset to retrieve
+  -n, --packagename=packagename                   the package.xml will be saved to this path
+
+  -p, --savepackage                               save the package.xml in manifest/changesets/<change set
+                                                  name>/package.xml
+
   -u, --targetusername=targetusername             username or alias for the target org; overrides default target org
+
   --apiversion=apiversion                         override the api version used for api requests made by this command
+
   --json                                          format output as json
+
   --loglevel=(trace|debug|info|warn|error|fatal)  [default: warn] logging level for this command invocation
 
-EXAMPLE
+EXAMPLES
   $ sfdx changeset:retrieve --targetusername myOrg@example.com --changeset "Name of Changeset"
      Retrieving Changeset... Done!
      Extracting Package... Done!
      Converting to Source... Done!
+     Cleaning up temporary files... Done!
+  
+  $ sfdx changeset:retrieve --targetusername myOrg@example.com --changeset "Name of Changeset" -p
+     Retrieving Changeset... Done!
+     Extracting Package... Done!
+     Converting to Source... Done!
+     Saving manifest/changesets/Name-of-Changeset-package.xml... Done!
+     Cleaning up temporary files... Done!
+  
+  $ sfdx changeset:retrieve --targetusername myOrg@example.com --changeset "Name of Changeset" -n manifest/pack.xml
+     Retrieving Changeset... Done!
+     Extracting Package... Done!
+     Converting to Source... Done!
+     Saving manifest/pack.xml... Done!
      Cleaning up temporary files... Done!
 ```
 

--- a/messages/retrieve.json
+++ b/messages/retrieve.json
@@ -1,4 +1,8 @@
 {
   "commandDescription": "Download a changeset to the project",
-  "changesetnameFlagDescription": "name of changeset to retrieve"
+  "changesetnameFlagDescription": "name of changeset to retrieve",
+  "packagenameFlagDescription": "the package.xml will be saved to this path",
+  "savepackageFlagDescription": "save the package.xml in manifest/changesets/<change set name>/package.xml",
+
+  "packageFlagsError": "please use either of the flags -n <path> or -p, but not both"
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@salesforce/core": "^1.3.2",
     "adm-zip": "^0.4.13",
     "del": "^4.1.0",
+    "slugify": "^1.4.6",
+    "strip-color": "^0.1.0",
     "tslib": "^1"
   },
   "devDependencies": {

--- a/src/lib/execProm.ts
+++ b/src/lib/execProm.ts
@@ -1,0 +1,30 @@
+import { exec } from 'child_process';
+import * as stripcolor from 'strip-color';
+import * as util from 'util';
+
+const execProm = util.promisify(exec);
+
+// tslint:disable-next-line: no-any
+const exec2JSON = async (cmd: string, options = {}): Promise<any> => {
+    try {
+        const results = await execProm(cmd, options);
+        return JSON.parse(stripcolor(results.stdout));
+    } catch (err) {
+        // console.log(err);
+        return JSON.parse(stripcolor(err.stdout));
+    }
+};
+
+// tslint:disable-next-line: no-any
+const exec2String = async (cmd: string, options = {}): Promise<any> => {
+    try {
+        const results = await execProm(cmd, options);
+        return results.stdout;
+    } catch (err) {
+        // console.log(err);
+        return err.stdout;
+    }
+};
+
+export { execProm, exec2JSON, exec2String };
+export { execProm as exec };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,6 +3033,11 @@ slash@^1.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
+slugify@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.6.tgz#ef288d920a47fb01c2be56b3487b6722f5e34ace"
+  integrity sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -3243,6 +3248,11 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
+strip-color@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/strip-color/-/strip-color-0.1.0.tgz#106f65d3d3e6a2d9401cac0eb0ce8b8a702b4f7b"
+  integrity sha1-EG9l09PmotlAHKwOsM6LinArT3s=
 
 strip-eof@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**$ sfdx changeset:retrieve -h**

Download a changeset to the project

USAGE
  $ sfdx changeset:retrieve -c <string> [-n <string>] [-p] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal]

OPTIONS
  -c, --changesetname=changesetname               (required) name of changeset to retrieve
  -n, --packagename=packagename                   the package.xml will be saved to this path
  -p, --savepackage                               save the package.xml in manifest/changesets/<change set name>/package.xml
  -u, --targetusername=targetusername             username or alias for the target org; overrides default target org
  --apiversion=apiversion                         override the api version used for api requests made by this command
  --json                                          format output as json
  --loglevel=(trace|debug|info|warn|error|fatal)  [default: warn] logging level for this command invocation

EXAMPLES
  $ sfdx changeset:retrieve --targetusername myOrg@example.com --changeset "Name of Changeset"
     Retrieving Changeset... Done!
     Extracting Package... Done!
     Converting to Source... Done!
     Cleaning up temporary files... Done!
  
  $ sfdx changeset:retrieve --targetusername myOrg@example.com --changeset "Name of Changeset" -p
     Retrieving Changeset... Done!
     Extracting Package... Done!
     Converting to Source... Done!
     Saving manifest/changesets/Name-of-Changeset-package.xml... Done!
     Cleaning up temporary files... Done!
  
  $ sfdx changeset:retrieve --targetusername myOrg@example.com --changeset "Name of Changeset" -n manifest/pack.xml
     Retrieving Changeset... Done!
     Extracting Package... Done!
     Converting to Source... Done!
     Saving manifest/pack.xml... Done!
     Cleaning up temporary files... Done!